### PR TITLE
ci(Travis): run release stage only in master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ after_success: npx codecov
 jobs:
   include:
     - script: yarn test
+
     - stage: release
+      if: branch = master
       node_js: lts/*
       script: skip
       deploy:


### PR DESCRIPTION
Only run release job in master. This to prevent releases being made from Pull requests.