### PR TITLE
chore(now.json): fix paths to make deployments work

### DIFF
--- a/now.json
+++ b/now.json
@@ -2,11 +2,11 @@
   "name": "disputes",
   "version": 2,
   "builds": [
-    { "src": "packages/back-end/index.js", "use": "@now/node" },
-    { "src": "packages/front-end/package.json", "use": "@now/next" }
+    { "src": "apps/backend/index.js", "use": "@now/node" },
+    { "src": "apps/frontend/package.json", "use": "@now/next" }
   ],
   "routes": [
-    { "src": "/graphql(.*)", "dest": "packages/back-end/index.js" },
-    { "src": "/(.*)", "dest": "packages/front-end/$1" }
+    { "src": "/graphql(.*)", "dest": "apps/backend/index.js" },
+    { "src": "/(.*)", "dest": "apps/frontend/$1" }
   ]
 }


### PR DESCRIPTION
**What:** fix `now.json` 

**Why:** to have Now deployments work correctly

**How:** fixing paths after renaming
