### PR TITLE
chore(lerna): use version instead of publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,9 @@ node_js:
   - lts/*
 cache: yarn
 after_success: npx codecov
-
 jobs:
   include:
     - script: yarn test:coverage
-
     - stage: release
       if: branch = master
       node_js: lts/*
@@ -15,10 +13,13 @@ jobs:
       deploy:
         provider: script
         skip_cleanup: true
-        script: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc && git remote set-url origin https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git && git checkout master && lerna publish --yes --skip-npm
+        script:
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc && git
+          remote set-url origin https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+          && git checkout master && lerna version --yes
 
 notifications:
   email: false
   slack:
-    secure: Q1bOmAwZB3a7CpFiQosC1miaiS33OvTraGjukdVedhmKbd2G3HCjYQP9x/lqVv2TNVN1L77dgbKnw+ujYBaFG7JHKT+GTylKIOm/I8l4ZiwmpctQGgFrknOUmOagIO18nWvEKGd+yzK55zbqoV3mOXan/6V04yO8iqVQLX6k1vm2oENU9GUU5tqYcVVHuIRWD7xaRRO9EZ3ClMf3Vp5DUg/2YVRvpk7rqnV2MFAdS4k/ckdwAPqXEMC/MaGvB1pYpbYCDIs3xpf8Apon8hN7gDFO7ZLPUJ0yArPulKui/iEOxfF2vmVTnnr/9ziosNpFG8MJvhJ+lmIaMTwmKDGOjLxP3fwoxszxOR0a0SAiQWB3K/aceFkqsMacLzgjrCCdjpkOzhM9bas/ooZMNIlKaf9VkHoG9UWDdEpJ8G2u+aVixk7Ag5TMDIRy98JQRS1WjFUUnjM07VQR3UZg6oBYH8zt9/ZDWOd5t52AIpnJd+fijtr0RLMUikIFOPXRydV0l57mgen3CWODh3nZwCOBmDHN3FLbf57/Od2sAvVj1YBB5LduXWo8uBRhqVTWjVCfzSvrlYoRJkbrDPFAzvCDa2VJ8a7CNjqJ1AumCt3ixsjuHBEgqUOaGN1muMi/nrV82U9rtrOxCunhE4X8giW6uMhfGYigQCDOrDoPcQOAUGI=
-    on_success: change
+    rooms:
+      - secure: VPeA03hlpRGJFONZKoaN0amAaCxtLEon/iliugf7jeWUUpcCmABOlLSWPX6LFKdbnq5NC1ewudpz5dQVfC/HD1IWTIY3s5ACMv1VGplio4qOGU+uaxJ10UvYh5ybv6c9AchDgb+kI0l8B/11YwzJHE4M3Kht9Ab89GIgdhrCuPBXliev8ixVqOEg7+YwhvrXgx1SPEdvMJFtH9/MdaCUDnSDfQDhg+gP+VX0pMcvZGggTqcrA63MwSDR+1hMHXKQXPJEFMR1mERPn22t8FLBCS7pwZVgzvMUcfINP8G3tgfBi93uo4NUbUUyPUlqBFFwetMH2RgFBEJAXckggRq8P3GYKhGInOxj4v2trU+m2MjTZ7Dvd8JSULOJqkdZhY+5vLCsLXz6W6M4Ws3FcDrdxS9jrPv62wmaxhNBfF/r25pGbESool2/oLlPW2k/Fxclr/QgP8ZRcNJ7X0KU32Glb0rtnxZasehOwmiUJv5g6GlBozE5/06RQMmSF1OMD5CEj0FNDDE+V2grj1NBxMVabDeHVLGhmmwlck1TjQT+9uWYPwgcX4bfJrgRqzCVIjM6UoobAANLvlCv183sOAeSO+5Qv5QGvhg8uIqTBFC5bkCLo0mDMRMBBAajcY5K1qyM3ZabTcTQc4mm/vbFGHVViJ0XDEfXZzc6aFh0UwHJrX0=

--- a/lerna.json
+++ b/lerna.json
@@ -1,13 +1,16 @@
 {
   "npmClient": "yarn",
-  "packages": [
-    "apps/*"
-  ],
+  "packages": ["apps/*"],
   "version": "0.0.2",
   "useWorkspaces": true,
+  "ignoreChanges": ["**/__fixtures__/**", "**/__tests__/**", "**/*.md"],
   "command": {
     "publish": {
       "conventionalCommits": true
+    },
+    "version": {
+      "conventionalCommits": true,
+      "githubRelease": true
     }
   }
 }


### PR DESCRIPTION
**What:** change lerna command from `publish` to `version`

**Why:** since we don't need to publish packages to npm, `version` is the command we should be using

**How:** change the command in `.travis.yml` release stage
