### PR TITLE
Add better selection controls

### DIFF
--- a/apps/frontend/components/CheckField.js
+++ b/apps/frontend/components/CheckField.js
@@ -1,9 +1,11 @@
+import _ from "lodash";
 import {
   Checkbox,
   FormControl,
   FormControlLabel,
   FormGroup,
   FormHelperText,
+  FormLabel,
   Typography,
 } from "@material-ui/core";
 import React, { useState } from "react";
@@ -12,14 +14,16 @@ const CheckField = props => {
   const {
     children,
     classNames,
+    schema,
     id,
     label,
     rawDescription,
     rawErrors,
     rawHelp,
+    required,
   } = props;
 
-  const [checked, setChecked] = useState(false);
+  const [checkedValues, setCheckedValues] = useState([]);
   const hasError = rawErrors !== undefined;
 
   return (
@@ -29,21 +33,45 @@ const CheckField = props => {
         if (!React.isValidElement(child)) return null;
 
         return (
-          <FormControl component="fieldset">
+          <FormControl
+            error={hasError}
+            required={required}
+            component="fieldset"
+            data-testid="checkbox"
+          >
+            <FormLabel component="legend">{label}</FormLabel>
             <FormGroup>
-              <FormControlLabel
-                data-testid="checkbox"
-                control={
-                  <Checkbox
-                    checked={checked}
-                    onChange={() => {
-                      child.props.onChange(!checked);
-                      setChecked(!checked);
-                    }}
-                  />
-                }
-                label={label}
-              />
+              {schema.items.enum.map((optionValue, index) => (
+                <FormControlLabel
+                  key={`${id}-${optionValue}-${index}`}
+                  value={`${optionValue}`}
+                  control={
+                    <Checkbox
+                      checked={_.includes(checkedValues, optionValue)}
+                      onChange={e => {
+                        let newValueSet = [];
+
+                        if (_.includes(checkedValues, optionValue)) {
+                          newValueSet = _.difference(checkedValues, [
+                            optionValue,
+                          ]);
+                        } else {
+                          newValueSet = checkedValues.concat(e.target.value);
+                        }
+
+                        setCheckedValues(newValueSet);
+                        child.props.onChange(newValueSet);
+                      }}
+                      value={optionValue}
+                    />
+                  }
+                  label={_.get(
+                    schema,
+                    `items.enumNames[${index}]`,
+                    optionValue
+                  )}
+                />
+              ))}
             </FormGroup>
             <FormHelperText error={hasError} component="div">
               {hasError ? rawErrors : rawHelp}

--- a/apps/frontend/components/FieldTemplate.js
+++ b/apps/frontend/components/FieldTemplate.js
@@ -14,6 +14,8 @@ const FieldTemplate = props => {
     switch (uiSchema["ui:widget"]) {
       case "radio":
         return <RadioField {...props} />;
+      case "checkboxes":
+        return <CheckField {...props} />;
       default:
         return <PlainTemplate {...props} />;
     }
@@ -21,10 +23,6 @@ const FieldTemplate = props => {
 
   if (has(schema, "enum")) {
     return <SelectField {...props} />;
-  }
-
-  if (includes(["boolean"], schema.type)) {
-    return <CheckField {...props} />;
   }
 
   if (includes(["string", "number"], schema.type)) {

--- a/apps/frontend/components/FieldTemplate.js
+++ b/apps/frontend/components/FieldTemplate.js
@@ -2,6 +2,7 @@ import CheckField from "./CheckField";
 import has from "lodash/has";
 import includes from "lodash/includes";
 import PlainTemplate from "./PlainTemplate";
+import RadioField from "./RadioField";
 import React from "react";
 import SelectField from "./SelectField";
 import TextField from "./TextField";
@@ -10,7 +11,12 @@ const FieldTemplate = props => {
   const { schema, uiSchema } = props;
 
   if (has(uiSchema, "ui:widget")) {
-    return <PlainTemplate {...props} />;
+    switch (uiSchema["ui:widget"]) {
+      case "radio":
+        return <RadioField {...props} />;
+      default:
+        return <PlainTemplate {...props} />;
+    }
   }
 
   if (has(schema, "enum")) {

--- a/apps/frontend/components/RadioField.js
+++ b/apps/frontend/components/RadioField.js
@@ -35,9 +35,18 @@ const RadioField = props => {
           <FormControl component="fieldset" data-testid="radio">
             <FormLabel component="legend">{label}</FormLabel>
             <RadioGroup
-              aria-label={label}
+              aria-label={_.isEmpty(label) ? label : id}
+              name={child.props.name}
               value={value}
-              onChange={e => setValue(e.target.value)}
+              onChange={e => {
+                setValue(e.target.value);
+                // Allow to keep the same type asked by the Schema
+                let value =
+                  schema.type === "boolean"
+                    ? JSON.parse(e.target.value)
+                    : e.target.value;
+                child.props.onChange(value);
+              }}
             >
               {schema.enum.map((optionValue, index) => (
                 <FormControlLabel

--- a/apps/frontend/components/RadioField.js
+++ b/apps/frontend/components/RadioField.js
@@ -32,7 +32,11 @@ const RadioField = props => {
         if (!React.isValidElement(child)) return null;
 
         return (
-          <FormControl component="fieldset" data-testid="radio">
+          <FormControl
+            error={hasError}
+            component="fieldset"
+            data-testid="radio"
+          >
             <FormLabel component="legend">{label}</FormLabel>
             <RadioGroup
               aria-label={_.isEmpty(label) ? label : id}

--- a/apps/frontend/components/RadioField.js
+++ b/apps/frontend/components/RadioField.js
@@ -22,7 +22,9 @@ const RadioField = props => {
     rawHelp,
   } = props;
 
-  const [value, setValue] = useState();
+  // Values by default need to be handle has strings
+  const defaultValue = `${_.get(schema, "default")}`;
+  const [value, setValue] = useState(defaultValue);
   const hasError = rawErrors !== undefined;
 
   return (
@@ -56,7 +58,11 @@ const RadioField = props => {
                 <FormControlLabel
                   key={`${id}-${optionValue}-${index}`}
                   value={`${optionValue}`}
-                  control={<Radio />}
+                  control={
+                    <Radio
+                      inputProps={{ "data-testid": `option-${optionValue}` }}
+                    />
+                  }
                   label={_.get(schema, `enumNames[${index}]`, optionValue)}
                 />
               ))}

--- a/apps/frontend/components/RadioField.js
+++ b/apps/frontend/components/RadioField.js
@@ -1,0 +1,61 @@
+import _ from "lodash";
+import {
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  FormLabel,
+  Radio,
+  RadioGroup,
+  Typography,
+} from "@material-ui/core";
+import React, { useState } from "react";
+
+const RadioField = props => {
+  const {
+    children,
+    classNames,
+    id,
+    label,
+    rawDescription,
+    schema,
+    rawErrors,
+    rawHelp,
+  } = props;
+
+  const [value, setValue] = useState();
+  const hasError = rawErrors !== undefined;
+
+  return (
+    <div data-testid={id} className={classNames}>
+      {rawDescription && <Typography>{rawDescription}</Typography>}
+      {React.Children.map(children, child => {
+        if (!React.isValidElement(child)) return null;
+
+        return (
+          <FormControl component="fieldset" data-testid="radio">
+            <FormLabel component="legend">{label}</FormLabel>
+            <RadioGroup
+              aria-label={label}
+              value={value}
+              onChange={e => setValue(e.target.value)}
+            >
+              {schema.enum.map((optionValue, index) => (
+                <FormControlLabel
+                  key={`${id}-${optionValue}-${index}`}
+                  value={`${optionValue}`}
+                  control={<Radio />}
+                  label={_.get(schema, `enumNames[${index}]`, optionValue)}
+                />
+              ))}
+            </RadioGroup>
+            <FormHelperText error={hasError} component="div">
+              {hasError ? rawErrors : rawHelp}
+            </FormHelperText>
+          </FormControl>
+        );
+      })}
+    </div>
+  );
+};
+
+export default RadioField;

--- a/apps/frontend/components/___tests___/CheckField.spec.js
+++ b/apps/frontend/components/___tests___/CheckField.spec.js
@@ -4,18 +4,25 @@ import { cleanup, fireEvent, render } from "react-testing-library";
 
 describe("<CheckField />", () => {
   const baseProps = {
-    id: "root_foo",
-    label: "Foo Label",
+    id: "root_checkboxes",
+    label: "Choose:",
+    schema: {
+      items: {
+        enum: ["foo", "bar", "zoo"],
+        enumNames: ["Foo", "Bar", "Zoo"],
+      },
+      title:
+        "You believe your loan should not be paid because of a violation of state regulations related to your:",
+      type: "array",
+      uniqueItems: true,
+    },
+    uiSchema: { "ui:widget": "checkboxes" },
   };
 
   afterEach(cleanup);
 
-  const props = {
-    ...baseProps,
-    schema: { format: "telephone", type: "boolean" },
-  };
-
-  it("triggers input onChange callback on click", () => {
+  it("supports to render a group of options", () => {
+    const props = { ...baseProps };
     const onChange = jest.fn();
     const wrapper = render(
       <CheckField {...props}>
@@ -24,15 +31,37 @@ describe("<CheckField />", () => {
           className="form-control"
           id={baseProps.id}
           label={baseProps.label}
-          placeholder="Introduce Foo"
         />
       </CheckField>
     );
 
-    const customInput = wrapper.getByTestId("checkbox");
+    expect(wrapper.getByText(/foo/i)).toBeTruthy();
+    expect(wrapper.getByText(/bar/i)).toBeTruthy();
+    expect(wrapper.getByText(/zoo/i)).toBeTruthy();
+  });
 
-    fireEvent.click(customInput);
+  it("click a checkbox triggers input onChange callback", () => {
+    const props = { ...baseProps };
+    const onChange = jest.fn();
+    const wrapper = render(
+      <CheckField {...props}>
+        <input
+          onChange={onChange}
+          className="form-control"
+          id={baseProps.id}
+          label={baseProps.label}
+        />
+      </CheckField>
+    );
 
-    expect(onChange).toHaveBeenCalledTimes(1);
+    fireEvent.click(wrapper.getByLabelText(/bar/i));
+    fireEvent.click(wrapper.getByLabelText(/zoo/i));
+    fireEvent.click(wrapper.getByLabelText(/bar/i));
+
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(onChange).toHaveBeenNthCalledWith(1, ["bar"]);
+    expect(onChange).toHaveBeenNthCalledWith(2, ["bar", "zoo"]);
+    expect(onChange).toHaveBeenNthCalledWith(1, ["bar"]);
+    expect(onChange).toHaveBeenNthCalledWith(3, ["zoo"]);
   });
 });

--- a/apps/frontend/components/___tests___/FieldTemplate.spec.js
+++ b/apps/frontend/components/___tests___/FieldTemplate.spec.js
@@ -192,13 +192,34 @@ describe("<FieldTemplate />", () => {
   });
 
   describe("when uiSchema has a ui:widget definition", () => {
-    const props = {
-      ...baseProps,
-      schema: { type: "string" },
-      uiSchema: { "ui:widget": "foo" },
-    };
+    it("renders a custom radio button when ui:widget is \"radio\"", () => {
+      const props = {
+        ...baseProps,
+        schema: { type: "string" },
+        uiSchema: { "ui:widget": "radio" },
+      };
+
+      const wrapper = render(
+        <FieldTemplate {...props}>
+          <input
+            className="form-control"
+            id={baseProps.id}
+            label={baseProps.label}
+            placeholder="Introduce Foo"
+          />
+        </FieldTemplate>
+      );
+
+      expect(wrapper.getByTestId("radio")).toBeTruthy();
+    });
 
     it("renders a <PlainTemplate />", () => {
+      const props = {
+        ...baseProps,
+        schema: { type: "string" },
+        uiSchema: { "ui:widget": "foo" },
+      };
+
       const wrapper = render(
         <FieldTemplate {...props}>
           <input

--- a/apps/frontend/components/___tests___/FieldTemplate.spec.js
+++ b/apps/frontend/components/___tests___/FieldTemplate.spec.js
@@ -195,7 +195,7 @@ describe("<FieldTemplate />", () => {
     it("renders a custom radio button when ui:widget is \"radio\"", () => {
       const props = {
         ...baseProps,
-        schema: { type: "string" },
+        schema: { enum: ["Foo", "Bar"], type: "string" },
         uiSchema: { "ui:widget": "radio" },
       };
 

--- a/apps/frontend/components/___tests___/FieldTemplate.spec.js
+++ b/apps/frontend/components/___tests___/FieldTemplate.spec.js
@@ -115,25 +115,6 @@ describe("<FieldTemplate />", () => {
     });
   });
 
-  describe("when schema has type boolean", () => {
-    const props = { ...baseProps, schema: { type: "boolean" } };
-
-    it("renders a custom input component for checkbox", () => {
-      const wrapper = render(
-        <FieldTemplate {...props}>
-          <input
-            className="form-control"
-            id={baseProps.id}
-            label={baseProps.label}
-            placeholder="Introduce Foo"
-          />
-        </FieldTemplate>
-      );
-
-      expect(wrapper.getByTestId("checkbox")).toBeTruthy();
-    });
-  });
-
   describe("when schema has format date", () => {
     const props = { ...baseProps, schema: { format: "date", type: "string" } };
 
@@ -211,6 +192,26 @@ describe("<FieldTemplate />", () => {
       );
 
       expect(wrapper.getByTestId("radio")).toBeTruthy();
+    });
+
+    it("renders a custom checkbox when ui:widget is \"checkboxes\"", () => {
+      const props = {
+        ...baseProps,
+        schema: { items: { enum: ["Foo", "Bar"] }, type: "string" },
+        uiSchema: { "ui:widget": "checkboxes" },
+      };
+      const wrapper = render(
+        <FieldTemplate {...props}>
+          <input
+            className="form-control"
+            id={baseProps.id}
+            label={baseProps.label}
+            placeholder="Introduce Foo"
+          />
+        </FieldTemplate>
+      );
+
+      expect(wrapper.getByTestId("checkbox")).toBeTruthy();
     });
 
     it("renders a <PlainTemplate />", () => {

--- a/apps/frontend/components/___tests___/RadioField.spec.js
+++ b/apps/frontend/components/___tests___/RadioField.spec.js
@@ -1,3 +1,4 @@
+import "jest-dom/extend-expect";
 import RadioField from "../RadioField";
 import React from "react";
 import { cleanup, fireEvent, render } from "react-testing-library";
@@ -7,7 +8,6 @@ describe("<RadioField />", () => {
     id: "root_foo",
     label: "Foo Label",
     schema: {
-      default: false,
       enum: [true, false],
       enumNames: ["Yes", "No"],
       title: " ",
@@ -54,5 +54,26 @@ describe("<RadioField />", () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it("supports default value declaration", () => {
+    const props = {
+      ...baseProps,
+      schema: { ...baseProps.schema, default: false },
+    };
+    const onChange = jest.fn();
+    const wrapper = render(
+      <RadioField {...props}>
+        <input
+          onChange={onChange}
+          className="form-control"
+          id={baseProps.id}
+          label={baseProps.label}
+        />
+      </RadioField>
+    );
+
+    expect(wrapper.getByTestId(/option-false/i)).toHaveAttribute("checked");
+    expect(wrapper.getByTestId(/option-true/i)).not.toHaveAttribute("checked");
   });
 });

--- a/apps/frontend/components/___tests___/RadioField.spec.js
+++ b/apps/frontend/components/___tests___/RadioField.spec.js
@@ -1,0 +1,38 @@
+import RadioField from "../RadioField";
+import React from "react";
+import { cleanup, render } from "react-testing-library";
+
+describe("<RadioField />", () => {
+  const baseProps = {
+    id: "root_foo",
+    label: "Foo Label",
+    schema: {
+      default: false,
+      enum: [true, false],
+      enumNames: ["Yes", "No"],
+      title: " ",
+      type: "boolean",
+    },
+    uiSchema: { "ui:widget": "radio" },
+  };
+
+  afterEach(cleanup);
+
+  it("supports to render a group of options", () => {
+    const props = { ...baseProps };
+    const onChange = jest.fn();
+    const wrapper = render(
+      <RadioField {...props}>
+        <input
+          onChange={onChange}
+          className="form-control"
+          id={baseProps.id}
+          label={baseProps.label}
+        />
+      </RadioField>
+    );
+
+    expect(wrapper.getByText(/yes/i)).toBeTruthy();
+    expect(wrapper.getByText(/no/i)).toBeTruthy();
+  });
+});

--- a/apps/frontend/components/___tests___/RadioField.spec.js
+++ b/apps/frontend/components/___tests___/RadioField.spec.js
@@ -1,6 +1,6 @@
 import RadioField from "../RadioField";
 import React from "react";
-import { cleanup, render } from "react-testing-library";
+import { cleanup, fireEvent, render } from "react-testing-library";
 
 describe("<RadioField />", () => {
   const baseProps = {
@@ -34,5 +34,25 @@ describe("<RadioField />", () => {
 
     expect(wrapper.getByText(/yes/i)).toBeTruthy();
     expect(wrapper.getByText(/no/i)).toBeTruthy();
+  });
+
+  it("click a radio button triggers input onChange callback", () => {
+    const props = { ...baseProps };
+    const onChange = jest.fn();
+    const wrapper = render(
+      <RadioField {...props}>
+        <input
+          onChange={onChange}
+          className="form-control"
+          id={baseProps.id}
+          label={baseProps.label}
+        />
+      </RadioField>
+    );
+
+    fireEvent.click(wrapper.getByLabelText(/no/i));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(false);
   });
 });

--- a/apps/frontend/lib/disputes/taxes-offset-shared.js
+++ b/apps/frontend/lib/disputes/taxes-offset-shared.js
@@ -1,6 +1,7 @@
 import debtTypes from "./dispute-types";
 import personalInfo from "./personal-info";
 import usaStates from "./usa-states";
+import yesnoSchema from "./yesno-schema";
 
 const schemas = {
   json: {
@@ -19,62 +20,43 @@ const schemas = {
     },
     properties: {
       FFELLoan: {
-        dependencies: {
-          "ffel-loan-radio-option": {
-            oneOf: [
-              {
-                properties: {
-                  "ffel-loan-radio-option": {
-                    enum: [false],
-                  },
-                },
-              },
-              {
-                properties: {
-                  "ffel-loan-radio-option": {
-                    enum: [true],
-                  },
-                  guarantyAgency: {
-                    properties: {
-                      guarantyAgency: {
-                        title: "Name",
-                        type: "string",
-                      },
-                      guarantyAgencyCity: {
-                        title: "City",
-                        type: "string",
-                      },
-                      guarantyAgencyMailingAddress: {
-                        title: "Address",
-                        type: "string",
-                      },
-                      guarantyAgencyState: {
-                        $ref: "#/definitions/usa-states",
-                        title: "State",
-                      },
-                      guarantyAgencyZipCode: {
-                        pattern: "[0-9]{5}",
-                        title: "Zip Code",
-                        type: "string",
-                      },
-                    },
-                    required: ["address", "city", "name", "state", "zip-code"],
-                    title: "Guaranty Agency details",
-                    type: "object",
-                  },
-                },
-                required: ["ffel-loan-radio-option", "guarantyAgency"],
-              },
-            ],
-          },
-        },
         properties: {
-          "ffel-loan-radio-option": {
+          "ffel-loan-radio-option-group": yesnoSchema({
             description:
               "If you have a FFEL loan, add the name and address of your guaranty agency in the box below. The name and address may appear on the tax offset notice you received in the mail. If you don't know the name and address of your guarantor, you can contact the Department of Education or call 1-800-304-3107 and ask for this information.",
+            keyName: "ffel-loan-radio-option",
             title: "Are you a FFEL holder?",
-            type: "boolean",
-          },
+            yesProps: {
+              guarantyAgencyDetails: {
+                properties: {
+                  guarantyAgency: {
+                    title: "Name",
+                    type: "string",
+                  },
+                  guarantyAgencyCity: {
+                    title: "City",
+                    type: "string",
+                  },
+                  guarantyAgencyMailingAddress: {
+                    title: "Address",
+                    type: "string",
+                  },
+                  guarantyAgencyState: {
+                    $ref: "#/definitions/usa-states",
+                    title: "State",
+                  },
+                  guarantyAgencyZipCode: {
+                    pattern: "[0-9]{5}",
+                    title: "Zip Code",
+                    type: "string",
+                  },
+                },
+                required: ["address", "city", "name", "state", "zip-code"],
+                title: "Guaranty Agency details",
+                type: "object",
+              },
+            },
+          }),
         },
         title: "FFEL Loan",
         type: "object",
@@ -158,7 +140,14 @@ const schemas = {
     type: "object",
   },
   ui: {
-    FFELLoan: { "ui:order": ["*"] },
+    FFELLoan: {
+      "ffel-loan-radio-option-group": {
+        "ffel-loan-radio-option": {
+          "ui:widget": "radio",
+        },
+      },
+      "ui:order": ["*"],
+    },
     personalInformation: {
       "ui:order": [
         "name",

--- a/apps/frontend/lib/disputes/yesno-schema.js
+++ b/apps/frontend/lib/disputes/yesno-schema.js
@@ -9,7 +9,7 @@ import keys from "lodash/keys";
  * into the uiSchema to render `"ui:widget": "radio"`
  */
 
-export default ({ keyName, title, yesProps, noProps }) => {
+export default ({ keyName, yesProps, noProps, ...rest }) => {
   const yesKeysPros = keys(yesProps);
   const noKeysPros = keys(noProps);
 
@@ -47,7 +47,7 @@ export default ({ keyName, title, yesProps, noProps }) => {
         type: "boolean",
       },
     },
-    title,
+    ...rest,
     type: "object",
   };
 };

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -43,8 +43,9 @@
     "eslint-plugin-react": "7.13.0",
     "flow-bin": "0.98.1",
     "jest": "24.8.0",
-    "lint-staged": "8.1.7",
-    "react-testing-library": "7.0.1",
+    "jest-dom": "^3.2.2",
+    "lint-staged": "8.1.6",
+    "react-testing-library": "7.0.0",
     "start-server-and-test": "~1.9.0",
     "waait": "1.0.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4230,7 +4230,12 @@ css-vendor@^0.3.8:
   dependencies:
     is-in-browser "^1.0.2"
 
-css@^2.2.4:
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^2.2.3, css@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
   integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
@@ -7029,7 +7034,7 @@ jest-config@^24.8.0:
     pretty-format "^24.8.0"
     realpath-native "^1.1.0"
 
-jest-diff@^24.8.0:
+jest-diff@^24.0.0, jest-diff@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.8.0.tgz#146435e7d1e3ffdf293d53ff97e193f1d1546172"
   integrity sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==
@@ -7045,6 +7050,20 @@ jest-docblock@^24.3.0:
   integrity sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==
   dependencies:
     detect-newline "^2.1.0"
+
+jest-dom@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jest-dom/-/jest-dom-3.2.2.tgz#4876c173045ae040f12220c56eb2555ef328fd94"
+  integrity sha512-Fnq3Y6d0MoDAJV8pAXkqe/e4VTBihRGaJypXvaHTLL9oRYzOvz0Q04evi5SBwPQ7FBiujQQOPXoEgEBGTg5BaA==
+  dependencies:
+    chalk "^2.4.1"
+    css "^2.2.3"
+    css.escape "^1.5.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    lodash "^4.17.11"
+    pretty-format "^24.0.0"
+    redent "^2.0.0"
 
 jest-each@^24.8.0:
   version "24.8.0"
@@ -7133,7 +7152,7 @@ jest-leak-detector@^24.8.0:
   dependencies:
     pretty-format "^24.8.0"
 
-jest-matcher-utils@^24.8.0:
+jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz#2bce42204c9af12bde46f83dc839efe8be832495"
   integrity sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==
@@ -9804,7 +9823,7 @@ pretty-format@^23.0.1:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-pretty-format@^24.7.0, pretty-format@^24.8.0:
+pretty-format@^24.0.0, pretty-format@^24.7.0, pretty-format@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.8.0.tgz#8dae7044f58db7cb8be245383b565a963e3c27f2"
   integrity sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==


### PR DESCRIPTION
**Disclaimer:** This PR is better to be merged after #79 

**What:**
- Map radio buttons to `<RadioField />` **new** component
- Add better `<CheckField />` as it is now used with a group of option

_As an extra we update the FELL to use "yesno" schema introduced in PR #79_

**Why:** related to #9 

**How:**
- Add new component `<RadioField />`
- Follow the same approach that newly created `<RadioField />` into `<CheckField />`
