### PR TITLE
Add GUIDE documentation

### DIFF
--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -32,3 +32,7 @@ That will run the tests in the terminal. If you prefer to run Cypress with GUI u
 ```bash
 yarn cypress open
 ```
+
+## Things you need to know
+
+In order to satisfy all the needs of the project, there is some custom code on top of the tecnologies we use that will be further described in [our guide](./docs/GUIDE.md)

--- a/apps/frontend/docs/GUIDE.md
+++ b/apps/frontend/docs/GUIDE.md
@@ -1,0 +1,62 @@
+# Table of Content
+
+- [Forms](#forms)
+  - [Advance Customization](#advance-customization)
+  - [Custom Formats](#custom-formats)
+  - [Factories](#factories)
+    - [yesno](#yesno)
+  - [Dependencies](#dependencies)
+
+# Forms
+
+## Advance Customization
+
+As we are using the [Mozilla's project](https://react-jsonschema-form.readthedocs.io/en/latest/) to handle forms all the rules intended to ddeclare schemas will apply, further help related to it can be found within their [advanced customization guide](https://react-jsonschema-form.readthedocs.io/en/latest/advanced-customization/)
+
+## Custom Formats
+
+While [JSON Schema](https://json-schema.org/understanding-json-schema/reference/string.html#format) supports just certain formats we also need to handle things like _telephone_ and _currency_ in order to do so we have custom formating.
+
+Our `<TextField />` component supports an special keyword in their schema called `$format` in which we can specify `telephone` and `currency`. In order for that to happen the schema needs to be of type `number`.
+
+```js
+{
+  phone: {
+    $format: "telephone",
+    title: "Your telephone",
+    type: "number",
+  },
+}
+```
+
+Take a look to the code at its [test suite](https://github.com/debtcollective/disputes/blob/master/apps/frontend/components/___tests___/TextField.spec.js) for some more context.
+
+## Factories
+
+While we enforce being explicit over abstractions there are some exceptions to facilitate the way of a developer create the schemas. There are common cases that needs a lot of boilerplate to define certain behaviour in which some factories take place.
+
+### yesno
+
+This factory is used on the cases where there are yes/no questions that need to be answered and typically one of the answers will lead to a branch within the form _(an extra of questions to be filled)_. Typically the usage can be described as the example below:
+
+```js
+"test-group": yesnoSchema({
+  defaultValue: false,
+  keyName: "test",
+  title: "Are you sure about this?",
+  yesProps: {
+    "test-why": {
+      title: "Why you were sure?",
+      type: "string",
+    },
+  },
+}),
+```
+
+The example above will return a JSON Schema that renders a question of _"Are you sure about this?"_ with two possible answers `yes` and `no`. By default will be selected the `No`, since `defaultValue` is `false` _(if defaultValue is not set `false` will be its value)_. If the user clicks on `Yes` it will render an extra question of _"Why you were sure?"_.
+
+## Dependencies
+
+We use some custom libraries to render some of our Material Components on top of [Marterial UI](https://material-ui.com/)
+- [react-number-format](https://github.com/s-yadav/react-number-format)
+- [material-ui-time-picker](https://github.com/TeamWertarbyte/material-ui-time-picker)

--- a/apps/frontend/lib/disputes/yesno-schema.js
+++ b/apps/frontend/lib/disputes/yesno-schema.js
@@ -9,7 +9,7 @@ import keys from "lodash/keys";
  * into the uiSchema to render `"ui:widget": "radio"`
  */
 
-export default ({ keyName, yesProps, noProps, ...rest }) => {
+export default ({ keyName, defaultValue, yesProps, noProps, ...rest }) => {
   const yesKeysPros = keys(yesProps);
   const noKeysPros = keys(noProps);
 
@@ -40,7 +40,7 @@ export default ({ keyName, yesProps, noProps, ...rest }) => {
     },
     properties: {
       [keyName]: {
-        default: false,
+        default: defaultValue || false,
         enum: [true, false],
         enumNames: ["Yes", "No"],
         title: " ",


### PR DESCRIPTION
**What:** Add guide documentation for some of the custom decisions we made for the project

**Why:** Related to decisions made while developing #9 

**How:** 
- Add a new document `GUIDE.md` under `docs/` and make a reference to it on README.md

_As extra we have updated the yesno factory with a minor change to support custom default value_
