### PR TITLE
Add Credit Report schema

### DIFF
--- a/apps/frontend/__tests__/__snapshots__/index.test.js.snap
+++ b/apps/frontend/__tests__/__snapshots__/index.test.js.snap
@@ -75,9 +75,16 @@ exports[`With React Testing Library Snapshot Should match Snapshot 1`] = `
     <h1
       class="pages__Title-sc-6ucdmv-0 ixxnbT"
     >
-      Working
+      Styled component
     </h1>
     <ul>
+      <li>
+        <a
+          href="/disputes/credit-report"
+        >
+          Credit Report
+        </a>
+      </li>
       <li>
         <a
           href="/disputes/general"

--- a/apps/frontend/components/NumberField.js
+++ b/apps/frontend/components/NumberField.js
@@ -13,6 +13,11 @@ const getPropsByFormat = format => {
         prefix: "$",
         thousandSeparator: true,
       };
+    case "ssn":
+      return {
+        format: "###-##-####",
+        mask: "_",
+      };
     default:
       return {};
   }

--- a/apps/frontend/components/___tests___/TextField.spec.js
+++ b/apps/frontend/components/___tests___/TextField.spec.js
@@ -91,5 +91,33 @@ describe("<TextField />", () => {
         expect(customInput.value).toEqual("+1 (202) 555-0179");
       });
     });
+
+    describe("when format is ssn", () => {
+      const props = {
+        ...baseProps,
+        schema: { $format: "ssn", type: schemaType },
+      };
+
+      it("renders an input that masks ssn", () => {
+        const introducedNumber = 123456789;
+        const wrapper = render(
+          <TextField {...props}>
+            <input
+              onChange={jest.fn()}
+              className="form-control"
+              id={baseProps.id}
+              label={baseProps.label}
+              placeholder="Introduce Foo"
+            />
+          </TextField>
+        );
+
+        const customInput = wrapper.getByTestId("number-field");
+
+        fireEvent.change(customInput, { target: { value: introducedNumber } });
+
+        expect(customInput.value).toEqual("123-45-6789");
+      });
+    });
   });
 });

--- a/apps/frontend/cypress/plugins/index.js
+++ b/apps/frontend/cypress/plugins/index.js
@@ -1,0 +1,18 @@
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+// eslint-disable-next-line no-unused-vars
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+};

--- a/apps/frontend/cypress/support/commands.js
+++ b/apps/frontend/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add("login", (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This is will overwrite an existing command --
+// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })

--- a/apps/frontend/cypress/support/index.js
+++ b/apps/frontend/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import "./commands";
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/apps/frontend/docs/GUIDE.md
+++ b/apps/frontend/docs/GUIDE.md
@@ -41,7 +41,7 @@ As we are using the [react-jsonschema-form](https://react-jsonschema-form.readth
 
 While [JSON Schema](https://json-schema.org/understanding-json-schema/reference/string.html#format) supports just certain formats we also need to handle things like _telephone_ and _currency_ in order to do so we have custom formating.
 
-Our `<TextField />` component supports an special keyword in their schema called `$format` where you can specify a mask for the `number` type field. The values this field can have are `telephone` or `currency`.
+Our `<TextField />` component supports an special keyword in their schema called `$format` where you can specify a mask for the `number` type field. The values this field can have are `telephone`, `currency` or `ssn`.
 
 ```js
 {

--- a/apps/frontend/docs/GUIDE.md
+++ b/apps/frontend/docs/GUIDE.md
@@ -1,5 +1,6 @@
 # Table of Content
 
+- [Tools](#tools)
 - [Forms](#forms)
   - [Advance Customization](#advance-customization)
   - [Custom Formats](#custom-formats)
@@ -7,17 +8,40 @@
     - [yesno](#yesno)
   - [Dependencies](#dependencies)
 
+# Tools
+
+The Disputes app has many tools. A tool is a definition of a process that receives user input and triggers some actions at the end, in our case is legal documents generated for our user.
+
+## Directory structure
+
+```
+├── tools
+│   ├── tool
+│   │   ├── tool-schema.js
+│   │   ├── index.js
+```
+
+### tool-schema.js
+
+We use [JSON Schema](https://json-schema.org) to define our tool. This will be used to render the wizard and forms for the tool, as well as validating user input. For a quick intro to JSON Schema check this [guide](http://json-schema.org/learn/getting-started-step-by-step.html).
+
+**Mention the extensions we are making here**
+
+### index.js
+
+This file exports the Form react component configured with the schema.
+
 # Forms
 
 ## Advance Customization
 
-As we are using the [Mozilla's project](https://react-jsonschema-form.readthedocs.io/en/latest/) to handle forms all the rules intended to ddeclare schemas will apply, further help related to it can be found within their [advanced customization guide](https://react-jsonschema-form.readthedocs.io/en/latest/advanced-customization/)
+As we are using the [react-jsonschema-form](https://react-jsonschema-form.readthedocs.io/en/latest/) to handle forms all the rules intended to ddeclare schemas will apply, further help related to it can be found within their [advanced customization guide](https://react-jsonschema-form.readthedocs.io/en/latest/advanced-customization/)
 
 ## Custom Formats
 
 While [JSON Schema](https://json-schema.org/understanding-json-schema/reference/string.html#format) supports just certain formats we also need to handle things like _telephone_ and _currency_ in order to do so we have custom formating.
 
-Our `<TextField />` component supports an special keyword in their schema called `$format` in which we can specify `telephone` and `currency`. In order for that to happen the schema needs to be of type `number`.
+Our `<TextField />` component supports an special keyword in their schema called `$format` where you can specify a mask for the `number` type field. The values this field can have are `telephone` or `currency`.
 
 ```js
 {
@@ -29,7 +53,7 @@ Our `<TextField />` component supports an special keyword in their schema called
 }
 ```
 
-Take a look to the code at its [test suite](https://github.com/debtcollective/disputes/blob/master/apps/frontend/components/___tests___/TextField.spec.js) for some more context.
+Take a look to the code at [TextField tests](https://github.com/debtcollective/disputes/blob/master/apps/frontend/components/___tests___/TextField.spec.js) for context.
 
 ## Factories
 
@@ -58,5 +82,6 @@ The example above will return a JSON Schema that renders a question of _"Are you
 ## Dependencies
 
 We use some custom libraries to render some of our Material Components on top of [Marterial UI](https://material-ui.com/)
+
 - [react-number-format](https://github.com/s-yadav/react-number-format)
 - [material-ui-time-picker](https://github.com/TeamWertarbyte/material-ui-time-picker)

--- a/apps/frontend/docs/GUIDE.md
+++ b/apps/frontend/docs/GUIDE.md
@@ -35,7 +35,7 @@ This file exports the Form react component configured with the schema.
 
 ## Advance Customization
 
-As we are using the [react-jsonschema-form](https://react-jsonschema-form.readthedocs.io/en/latest/) to handle forms all the rules intended to ddeclare schemas will apply, further help related to it can be found within their [advanced customization guide](https://react-jsonschema-form.readthedocs.io/en/latest/advanced-customization/)
+As we are using the [react-jsonschema-form](https://react-jsonschema-form.readthedocs.io/en/latest/) to handle forms all the rules intended to declare schemas will apply, further help related to it can be found within their [advanced customization guide](https://react-jsonschema-form.readthedocs.io/en/latest/advanced-customization/)
 
 ## Custom Formats
 

--- a/apps/frontend/lib/disputes/personal-info.js
+++ b/apps/frontend/lib/disputes/personal-info.js
@@ -13,6 +13,7 @@ export default {
     type: "string",
   },
   email: {
+    format: "email",
     title: "Email",
     type: "string",
   },

--- a/apps/frontend/lib/tools/credit-report/credit-report-schema.js
+++ b/apps/frontend/lib/tools/credit-report/credit-report-schema.js
@@ -1,0 +1,214 @@
+import debtTypes from "../../disputes/dispute-types";
+import usaStates from "../../disputes/usa-states";
+
+const schema = {
+  json: {
+    $schema: "http://json-schema.org/schema#",
+    definitions: {
+      "debt-types": {
+        enum: debtTypes.values,
+        enumNames: debtTypes.labels,
+        type: "string",
+      },
+      "usa-states": {
+        enum: usaStates.values,
+        enumNames: usaStates.labels,
+        type: "string",
+      },
+    },
+    description: `
+    Please have a photo of your picture ID ready to upload (taking a picture with your camera phone is fine).
+    <br><br>
+    Please make a list of all the errors that you want to dispute and be prepared to write a short statement explaining why those items should not negatively impact your credit. You will also have the option to upload a document highlighting errors on your report.
+    <br><br>
+    Please prepare all these materials before beginning this dispute. Once you begin, it will only take a few minutes to complete the dispute. Once you complete the dispute, a hard copy will be mailed to the credit reporting agency or agencies.',
+    `,
+    properties: {
+      debts: {
+        dependencies: {
+          debtType: {
+            oneOf: [
+              {
+                properties: {
+                  debtType: {
+                    enum: [debtTypes.values[0]],
+                    title: debtTypes.labels[0],
+                  },
+                },
+              },
+              {
+                properties: {
+                  debtType: {
+                    enum: [debtTypes.values[1]],
+                    title: debtTypes.labels[1],
+                  },
+                },
+              },
+              {
+                properties: {
+                  debtDescription: {
+                    title: "Description",
+                    type: "string",
+                  },
+                  debtType: {
+                    enum: [debtTypes.values[2]],
+                    title: debtTypes.labels[2],
+                  },
+                },
+                required: ["debtDescription"],
+              },
+            ],
+          },
+        },
+        description:
+          "Please provide the amount of debt collectors claim you owe. This will help us better understand the types of debt you and our members are fighting.",
+        properties: {
+          debtAmount: {
+            $format: "currency",
+            title: "Amount",
+            type: "number",
+          },
+          debtType: {
+            $ref: "#/definitions/debt-types",
+            title: "Debt Type",
+            type: "string",
+          },
+        },
+        required: ["debtType", "debtAmount"],
+        title: "Amount of Debt Disputed",
+        type: "object",
+      },
+      personalInformation: {
+        properties: {
+          address: {
+            title: "Your Mailing Address",
+            type: "string",
+          },
+          agencies: {
+            description: "Reporting agencies your dispute will be sent to",
+            items: {
+              enum: ["Experian", "Equifax", "TransUnion"],
+              type: "string",
+            },
+            minItems: 1,
+            title: "Reporting agencies",
+            type: "array",
+            uniqueItems: true,
+          },
+          city: {
+            title: "Your City",
+            type: "string",
+          },
+          currentCreditor: {
+            title: "Current Creditor",
+            type: "string",
+          },
+          dob: {
+            format: "date",
+            title: "Your date of birth?",
+            type: "string",
+          },
+          email: {
+            format: "email",
+            title: "Your email",
+            type: "string",
+          },
+          name: {
+            title: "Your Full Name",
+            type: "string",
+          },
+          originalCreditor: {
+            title: "Original Creditor",
+            type: "string",
+          },
+          phone: {
+            $format: "telephone",
+            title: "Your telephone",
+            type: "number",
+          },
+          ssn: {
+            $format: "ssn",
+            title: "Your SSN",
+            type: "number",
+          },
+          state: {
+            $ref: "#/definitions/usa-states",
+            title: "Your State",
+          },
+          "zip-code": {
+            pattern: "[0-9]{5}",
+            title: "Your Zip Code",
+            type: "string",
+          },
+        },
+        required: [
+          "address",
+          "agencies",
+          "city",
+          "currentCreditor",
+          "dob",
+          "email",
+          "name",
+          "originalCreditor",
+          "phone",
+          "ssn",
+          "state",
+          "zip-code",
+        ],
+        title: "Personal Information",
+        type: "object",
+      },
+    },
+    title: "Dispute Any Debt in Collections",
+    type: "object",
+  },
+  ui: {
+    debts: {
+      debtAmount: {
+        classNames: "prefix-currency",
+      },
+      debtType: {
+        "ui:help": "If you don't see your type of debt, choose 'Other'",
+        "ui:placeholder": "Select one",
+      },
+    },
+    personalInformation: {
+      address: {
+        "ui:placeholder": "Street, unit number, floor, door number",
+      },
+      city: {
+        classNames: "field-address",
+      },
+      name: {
+        "ui:placeholder": "Jane Doe",
+      },
+      ssn: {
+        "ui:placeholder": "###-##-####",
+      },
+      state: {
+        classNames: "field-address",
+        "ui:placeholder": "Select one",
+      },
+      "ui:order": [
+        "name",
+        "dob",
+        "ssn",
+        "address",
+        "city",
+        "state",
+        "zip-code",
+        "email",
+        "phone",
+        "currentCreditor",
+        "originalCreditor",
+        "agencies",
+      ],
+      "zip-code": {
+        classNames: "field-address",
+      },
+    },
+    "ui:order": ["*", "debts", "personalInformation"],
+  },
+};
+
+export default schema;

--- a/apps/frontend/lib/tools/credit-report/credit-report-schema.js
+++ b/apps/frontend/lib/tools/credit-report/credit-report-schema.js
@@ -176,6 +176,9 @@ const schema = {
       address: {
         "ui:placeholder": "Street, unit number, floor, door number",
       },
+      agencies: {
+        "ui:widget": "checkboxes",
+      },
       city: {
         classNames: "field-address",
       },

--- a/apps/frontend/lib/tools/credit-report/index.js
+++ b/apps/frontend/lib/tools/credit-report/index.js
@@ -1,0 +1,18 @@
+import FieldTemplate from "../../../components/FieldTemplate";
+import Form from "react-jsonschema-form";
+import React from "react";
+import schema from "./credit-report-schema";
+
+const CreditReport = () => (
+  <Form
+    showErrorList={false}
+    FieldTemplate={FieldTemplate}
+    uiSchema={schema.ui}
+    schema={schema.json}
+    onChange={() => console.log("changed")}
+    onSubmit={() => console.log("submitted")}
+    onError={() => console.log("errors")}
+  />
+);
+
+export default CreditReport;

--- a/apps/frontend/pages/disputes/credit-report.js
+++ b/apps/frontend/pages/disputes/credit-report.js
@@ -1,0 +1,3 @@
+import CreditReport from "../../lib/tools/credit-report";
+
+export default CreditReport;

--- a/apps/frontend/pages/index.js
+++ b/apps/frontend/pages/index.js
@@ -20,8 +20,13 @@ const Page = () => {
     <React.Fragment>
       <Header links={links} />
       <div>
-        <Title>Working</Title>
+        <Title>Styled component</Title>
         <ul>
+          <li>
+            <Link href="/disputes/credit-report">
+              <a>Credit Report</a>
+            </Link>
+          </li>
           <li>
             <Link href="/disputes/general">
               <a>General Dispute</a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -967,10 +967,10 @@
   resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-1.3.5.tgz#e5bf3837cbd3f5f5f5d7f49d8549e4118ea75f8d"
   integrity sha512-b0JQb10Lie07iW2/9uKCQSrXif262d6zfYBstCLLJUk0JVA+7o/yLDg5p2+GkjgJbmodjHozIXs4Bi34RRhL8Q==
 
-"@debtcollective/header@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@debtcollective/header/-/header-1.6.0.tgz#1e0f0409943597eaa2f3001fc8fd7a82291860aa"
-  integrity sha512-Ov/AC8Ou8UdKzuWCfNA7f/CwR+iTa+B1F0E4QJ7ZCub59uWkjP6toSXyDmNl9krL7NR1qQ+lc3rjshx1HSZ1oA==
+"@debtcollective/header@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@debtcollective/header/-/header-1.6.1.tgz#e7b857c41c68700b5bb0b7194547fcec928b5ea6"
+  integrity sha512-z366F3+6Vmf4XyGUwl4VFcQxdfcT9jHG9gJiHP3v78b6LY5Fr+yH7gmFcqqJPGnpqN+4BQt+Im9373bLFKSRiA==
 
 "@emotion/is-prop-valid@^0.7.3":
   version "0.7.3"


### PR DESCRIPTION
**What:** Add Credit Report Schema

**Why:** Closes #11 

**How:** Adding schema following the General dispute one.

## Notes

- Added some documentation around the tools, the idea is to keep improving this and add all the information about extensions we are making to JSON schema.

- Added a directory structure for tools, the idea is to use it for all the ones we write. Let me know what you think @duranmla, we can port the other ones to this structure after we merge this PR.

- Added a mask for `ssn` to the `NumberField`

## Media

![disputes-git-od-credit-report debtcollective now sh_disputes_credit-report (1)](https://user-images.githubusercontent.com/849872/58352903-954fa480-7e32-11e9-8d74-1d5fc54d5a67.png)