### PR TITLE
Port Private Student Loan Dispute tool

### DIFF
--- a/apps/frontend/__tests__/__snapshots__/index.test.js.snap
+++ b/apps/frontend/__tests__/__snapshots__/index.test.js.snap
@@ -192,6 +192,13 @@ exports[`With React Testing Library Snapshot Should match Snapshot 1`] = `
           </strong>
         </a>
       </li>
+      <li>
+        <a
+          href="/disputes/private-student-loan"
+        >
+          Private Student Loan
+        </a>
+      </li>
     </ul>
   </div>
 </DocumentFragment>

--- a/apps/frontend/components/FieldTemplate.js
+++ b/apps/frontend/components/FieldTemplate.js
@@ -25,7 +25,10 @@ const FieldTemplate = props => {
     return <SelectField {...props} />;
   }
 
-  if (includes(["string", "number"], schema.type)) {
+  if (
+    includes(["string", "number"], schema.type) &&
+    schema.format !== "data-url"
+  ) {
     return <TextField {...props} />;
   }
 

--- a/apps/frontend/components/___tests___/FieldTemplate.spec.js
+++ b/apps/frontend/components/___tests___/FieldTemplate.spec.js
@@ -235,4 +235,26 @@ describe("<FieldTemplate />", () => {
       expect(wrapper.getByTestId("plain-template")).toBeTruthy();
     });
   });
+
+  describe("when format is 'data-url'", () => {
+    it("renders a <PlainTemplate />", () => {
+      const props = {
+        ...baseProps,
+        schema: { format: "data-url", type: "string" },
+      };
+
+      const wrapper = render(
+        <FieldTemplate {...props}>
+          <input
+            className="form-control"
+            id={baseProps.id}
+            label={baseProps.label}
+            placeholder="Introduce Foo"
+          />
+        </FieldTemplate>
+      );
+
+      expect(wrapper.getByTestId("plain-template")).toBeTruthy();
+    });
+  });
 });

--- a/apps/frontend/lib/tools/student-loan/index.js
+++ b/apps/frontend/lib/tools/student-loan/index.js
@@ -1,0 +1,18 @@
+import FieldTemplate from "../../../components/FieldTemplate";
+import Form from "react-jsonschema-form";
+import React from "react";
+import schema from "./private-student-loan-schema";
+
+const PrivateStudentLoan = () => (
+  <Form
+    showErrorList={false}
+    FieldTemplate={FieldTemplate}
+    uiSchema={schema.ui}
+    schema={schema.json}
+    onChange={() => console.log("changed")}
+    onSubmit={() => console.log("submitted")}
+    onError={() => console.log("errors")}
+  />
+);
+
+export default PrivateStudentLoan;

--- a/apps/frontend/lib/tools/student-loan/private-student-loan-schema.js
+++ b/apps/frontend/lib/tools/student-loan/private-student-loan-schema.js
@@ -1,0 +1,214 @@
+import debtTypes from "../../disputes/dispute-types";
+import usaStates from "../../disputes/usa-states";
+
+const schema = {
+  json: {
+    $schema: "http://json-schema.org/schema#",
+    definitions: {
+      "debt-types": {
+        enum: debtTypes.values,
+        enumNames: debtTypes.labels,
+        type: "string",
+      },
+      "usa-states": {
+        enum: usaStates.values,
+        enumNames: usaStates.labels,
+        type: "string",
+      },
+    },
+    description: `
+    We can't tell you how long it will take for you to hear a response from the debt collector, since each collector handles disputes differently. We will prompt you to notify us when you get a reply. We are watching what happens with these disputes very closely so that we can find out which creditors are breaking the law and so we can find ways to work collectively to challenge them.
+    Before you begin, please have on hand a digital copy of letter you received in the mail from the collection agency or law firm.',
+    `,
+    properties: {
+      debts: {
+        dependencies: {
+          debtType: {
+            oneOf: [
+              {
+                properties: {
+                  debtType: {
+                    enum: [debtTypes.values[0]],
+                    title: debtTypes.labels[0],
+                  },
+                },
+              },
+              {
+                properties: {
+                  debtType: {
+                    enum: [debtTypes.values[1]],
+                    title: debtTypes.labels[1],
+                  },
+                },
+              },
+              {
+                properties: {
+                  debtDescription: {
+                    title: "Description",
+                    type: "string",
+                  },
+                  debtType: {
+                    enum: [debtTypes.values[2]],
+                    title: debtTypes.labels[2],
+                  },
+                },
+                required: ["debtDescription"],
+              },
+            ],
+          },
+        },
+        description:
+          "Please provide the amount of debt collectors claim you owe. This will help us better understand the types of debt you and our members are fighting.",
+        properties: {
+          debtAmount: {
+            $format: "currency",
+            title: "Amount",
+            type: "number",
+          },
+          debtType: {
+            $ref: "#/definitions/debt-types",
+            title: "Debt Type",
+            type: "string",
+          },
+        },
+        required: ["debtType", "debtAmount"],
+        title: "Amount of Debt Disputed",
+        type: "object",
+      },
+      personalInformation: {
+        description: "Here we need some personal information.",
+        properties: {
+          "account-number": {
+            title: "Account Number",
+            type: "number",
+          },
+          address: {
+            title: "Your Mailing Address",
+            type: "string",
+          },
+          city: {
+            title: "Your City",
+            type: "string",
+          },
+          // TODO: validate upload type JPEG, PNG, PDF and max file size 5242880
+          "collections-letter-uploader": {
+            description:
+              "Digital copy of letter you received in the mail from the collection agency or law firm",
+            items: {
+              format: "data-url",
+              type: "string",
+            },
+            title: "Collections Letter",
+            type: "array",
+          },
+          "firm-address": {
+            title: "Collection agency’s or law firm’s mailing address",
+            type: "string",
+          },
+          "firm-city": {
+            title: "Collection agency’s or law firm’s City",
+            type: "string",
+          },
+          "firm-name": {
+            title:
+              "Name of the collection agency, firm, or creditor who last contacted you",
+            type: "string",
+          },
+          "firm-state": {
+            $ref: "#/definitions/usa-states",
+            title: "Collection agency’s or law firm’s State",
+          },
+          "firm-zip-code": {
+            pattern: "[0-9]{5}",
+            title: "Collection agency’s or law firm’s Zip Code",
+            type: "string",
+          },
+          "is-debt-in-default": {
+            default: false,
+            enum: [true, false],
+            enumNames: ["Yes", "No"],
+            title: "Is your debt in default?",
+            type: "boolean",
+          },
+          "last-correspondence-date": {
+            format: "date",
+            title: "Date of Last Correspondence",
+            type: "string",
+          },
+          name: {
+            title: "Your Full Name",
+            type: "string",
+          },
+          state: {
+            $ref: "#/definitions/usa-states",
+            title: "Your State",
+          },
+          "zip-code": {
+            pattern: "[0-9]{5}",
+            title: "Your Zip Code",
+            type: "string",
+          },
+        },
+        required: [
+          "account-number",
+          "address",
+          "city",
+          "collections-letter-uploader",
+          "firm-address",
+          "firm-city",
+          "firm-name",
+          "firm-state",
+          "firm-zip-code",
+          "is-debt-in-default",
+          "last-correspondence-date",
+          "name",
+          "state",
+          "zip-code",
+        ],
+        title: "Personal Information Form",
+        type: "object",
+      },
+    },
+    required: ["debts", "personalInformation"],
+    title: "Gather Materials",
+    type: "object",
+  },
+  ui: {
+    debts: {
+      debtType: {
+        "ui:help": "If you don't see your type of debt, choose 'Other'",
+        "ui:placeholder": "Select one",
+      },
+    },
+    personalInformation: {
+      address: {
+        "ui:placeholder": "Street, unit number, floor, door number",
+      },
+      ssn: {
+        "ui:placeholder": "###-##-####",
+      },
+      state: {
+        "ui:placeholder": "Select one",
+      },
+      "ui:order": [
+        "name",
+        "address",
+        "city",
+        "state",
+        "zip-code",
+        "firm-name",
+        "firm-address",
+        "firm-city",
+        "firm-state",
+        "firm-zip-code",
+        "account-number",
+        "last-correspondence-date",
+        "is-debt-in-default",
+        "collections-letter-uploader",
+      ],
+    },
+    "ui:order": ["*", "debts", "personalInformation"],
+  },
+};
+
+export default schema;

--- a/apps/frontend/lib/tools/student-loan/private-student-loan-schema.js
+++ b/apps/frontend/lib/tools/student-loan/private-student-loan-schema.js
@@ -95,8 +95,14 @@ const schema = {
             description:
               "Digital copy of letter you received in the mail from the collection agency or law firm",
             items: {
-              format: "data-url",
-              type: "string",
+              properties: {
+                file: {
+                  format: "data-url",
+                  title: "A collection Letter",
+                  type: "string",
+                },
+              },
+              type: "object",
             },
             title: "Collections Letter",
             type: "array",

--- a/apps/frontend/pages/disputes/private-student-loan.js
+++ b/apps/frontend/pages/disputes/private-student-loan.js
@@ -1,0 +1,3 @@
+import PrivateStudentLoan from "../../lib/tools/student-loan";
+
+export default PrivateStudentLoan;

--- a/apps/frontend/pages/index.js
+++ b/apps/frontend/pages/index.js
@@ -102,6 +102,11 @@ const Page = () => {
               </a>
             </Link>
           </li>
+          <li>
+            <Link href="/disputes/private-student-loan">
+              <a>Private Student Loan</a>
+            </Link>
+          </li>
         </ul>
       </div>
     </React.Fragment>


### PR DESCRIPTION
**What:** Add private student loan dispute tool

**Why:** Closes #12 

**How:**
- Add a new schema

![http://recordit.co/9dHU0dHiSa](http://recordit.co/9dHU0dHiSa.gif)

**Extra:**
- We have bypassed `TextField` component to render `PlainTemplate` if the schema has a custom Mozilla format of `data-url` in order to render things as expected.

**Note:**
Keep in mind the buttons to add or remove attachments need styles and that we can choose to allow only a single file to be submitted.